### PR TITLE
Podspec for the FaceImageView

### DIFF
--- a/FaceImageView.podspec
+++ b/FaceImageView.podspec
@@ -5,10 +5,9 @@ Pod::Spec.new do |s|
   s.summary = 'A UIImageView clone that adjusts image content to show faces.'
   s.homepage = 'https://github.com/dingbat/faceimageview'
   s.authors = { 'Dan Hassin' => 'danhassin@mac.com'}
-  s.source = { :git => 'https://github.com/dingbat/faceimageview.git'}
+  s.source = { :git => 'https://github.com/dingbat/faceimageview.git', :tag => '0.1.0'}
   s.source_files = 'FaceImageView/FaceImageView.{h,m}'
   s.requires_arc = true
   s.ios.deployment_target = '5.0'
   s.ios.frameworks = 'CoreGraphics', 'CoreImage', 'QuartzCore'
 end
-  

--- a/FaceImageView.podspec
+++ b/FaceImageView.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name = 'FaceImageView'
+  s.version = '0.1.0'
+  s.license = 'MIT'
+  s.summary = 'A UIImageView clone that adjusts image content to show faces.'
+  s.homepage = 'https://github.com/dingbat/faceimageview'
+  s.authors = { 'Dan Hassin' => 'danhassin@mac.com'}
+  s.source = { :git => 'https://github.com/dingbat/faceimageview.git'}
+  s.source_files = 'FaceImageView/FaceImageView.{h,m}'
+  s.requires_arc = true
+  s.ios.deployment_target = '5.0'
+  s.ios.frameworks = 'CoreGraphics', 'CoreImage', 'QuartzCore'
+end
+  


### PR DESCRIPTION
A podspec file for the FaceImageView, it requires the generation of the tag **0.1.0** in order to pass the `pod spec lint` command.

As soon you approve the use of this pod spec we could commit this spec to the CocoaPods oficial specs repository
